### PR TITLE
fix: Importing logging into the curried function

### DIFF
--- a/examples/kube-deploy-hyperkops-example.yaml
+++ b/examples/kube-deploy-hyperkops-example.yaml
@@ -1,13 +1,12 @@
 ---
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: hyperkops-example
   namespace: datascience
   labels:
     app: hyperkops-example
 spec:
-  replicas: 1
   template:
     metadata:
       name: hyperkops-example
@@ -16,12 +15,19 @@ spec:
         app: hyperkops-example
     spec:
       containers:
-        - name: hyperkops-example
-          image: hipages/hyperkops-example:latest
+        - name: hipages/hyperkops-example:latest
+          image: hipages/
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "500Mi"
+            requests:
+              cpu: "500m"
+              memory: "500Mi"
           env:
             - name: MONGO_DB_ADDRESS
-              value: "hyperopt-mongo.datascience.svc.cluster.local"
+              value: "hyperkops-mongo.datascience.svc.cluster.local"
             - name: MONGO_DB_PORT
               value: "27017"
             - name: LOGLEVEL
@@ -29,10 +35,12 @@ spec:
             - name: TRIALS_DB
               value: "models"
             - name: TRIALS_COLLECTION
-              value: "models"
+              value: "jobs"
             - name: NUM_EVAL_STEPS
-              value: "1000"
+              value: "10"
             - name: MULTIPLIER
               value: "2"
-      restartPolicy: Always
+            - name: PYTHONUNBUFFERED
+              value: "1"
+      restartPolicy: OnFailure
 

--- a/examples/kube-deploy-hyperkops-example.yaml
+++ b/examples/kube-deploy-hyperkops-example.yaml
@@ -15,8 +15,8 @@ spec:
         app: hyperkops-example
     spec:
       containers:
-        - name: hipages/hyperkops-example:latest
-          image: hipages/
+        - name: hyperkops-example
+          image: hipages/hyperkops-example:latest
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/examples/kube-deploy-hyperkops-infrastructure.yaml
+++ b/examples/kube-deploy-hyperkops-infrastructure.yaml
@@ -35,6 +35,13 @@ spec:
         - name: hyperkops-worker
           image:  hipages/hyperkops-worker:latest
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "500Mi"
+            requests:
+              cpu: "500m"
+              memory: "500Mi"
           env:
             - name: MONGO_DB_ADDRESS
               value: "hyperkops-mongo.datascience.svc.cluster.local"
@@ -42,6 +49,8 @@ spec:
               value: "27017"
             - name: TRIALS_DB
               value: "models"
+            - name: PYTHONUNBUFFERED
+              value: "1"
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -83,6 +92,13 @@ spec:
         - name: hyerkops-monitor
           image: hipages/hyperkops-monitor:latest
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: "2000m"
+              memory: "500Mi"
+            requests:
+              cpu: "2000m"
+              memory: "500Mi"
           env:
             - name: MONGO_DB_ADDRESS
               value: "hyperkops-mongo.datascience.svc.cluster.local"
@@ -97,7 +113,7 @@ spec:
             - name: TRIALS_DB
               value: "models"
             - name: TRIALS_COLLECTION
-              value: "models"
+              value: "jobs"
             - name: NAMESPACE
               value: "datascience"
             - name: LABEL_SELECTOR

--- a/examples/optimisation.py
+++ b/examples/optimisation.py
@@ -104,7 +104,9 @@ def objective_currier(multiplier):
 
     def objective_curried(args):
         import logging as log
-        log.warning("Arguments parsed {}".format(args))
+
+        log.info("Arguments parsed {}".format(args))
+
         case, val = args
         if case == 'case 1':
             return val

--- a/examples/optimisation.py
+++ b/examples/optimisation.py
@@ -122,7 +122,7 @@ best = fmin(fn=object_curried,
             algo=tpe.suggest,
             max_evals=num_eval_steps,
             trials=trials,
-            verbose=9)
+            verbose=1)
 
 log.info("Finished Optimisation")
 # Get the values of the best space

--- a/examples/optimisation.py
+++ b/examples/optimisation.py
@@ -8,6 +8,8 @@ import uuid
 from hyperopt import hp, fmin, tpe, space_eval
 from hyperopt.mongoexp import MongoTrials
 
+# Set logging level from environment
+log.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 
 def environ_or_required(key):
     if os.environ.get(key):

--- a/examples/optimisation.py
+++ b/examples/optimisation.py
@@ -103,6 +103,8 @@ def objective_currier(multiplier):
     """
 
     def objective_curried(args):
+        import logging as log 
+        
         case, val = args
         log.debug("Arguments parsed {}".format(args))
         if case == 'case 1':

--- a/examples/optimisation.py
+++ b/examples/optimisation.py
@@ -103,10 +103,9 @@ def objective_currier(multiplier):
     """
 
     def objective_curried(args):
-        import logging as log 
-        
+        import logging as log
+        log.warning("Arguments parsed {}".format(args))
         case, val = args
-        log.debug("Arguments parsed {}".format(args))
         if case == 'case 1':
             return val
         else:
@@ -123,7 +122,7 @@ best = fmin(fn=object_curried,
             algo=tpe.suggest,
             max_evals=num_eval_steps,
             trials=trials,
-            verbose=1)
+            verbose=9)
 
 log.info("Finished Optimisation")
 # Get the values of the best space


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Importing logging into the curried function using an alias. This allows the example to be executed on remotely on the workers. 
* Adding changes to setting of log levels in example
* Updating the example kube manifest to change deployment to job

## How was this patch tested?
submitted from a local thread  by using docker-for-desktop through port forwarding.

![image](https://user-images.githubusercontent.com/18350465/60404606-e4d17f00-9bed-11e9-9246-1aac958a2051.png)

- Tested on branch in image

![image](https://user-images.githubusercontent.com/18350465/60404495-e189c380-9bec-11e9-8306-0944ebfbba7f.png)

