### PR TITLE
fix: Updating kube query to get running pods

### DIFF
--- a/examples/kube-deploy-hyperkops-infrastructure.yaml
+++ b/examples/kube-deploy-hyperkops-infrastructure.yaml
@@ -94,10 +94,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              cpu: "2000m"
+              cpu: "200m"
               memory: "500Mi"
             requests:
-              cpu: "2000m"
+              cpu: "200m"
               memory: "500Mi"
           env:
             - name: MONGO_DB_ADDRESS

--- a/hyperkops/monitor/kube_utils.py
+++ b/hyperkops/monitor/kube_utils.py
@@ -39,5 +39,8 @@ class KubeUtil:
         :return: a list of names of running pods
         """
         pod_status = self.get_status_of_all_pods(selector)
+        running_pods = [pod_info['pod'] for pod_info in pod_status if pod_info['phase'] == 'Running']
 
-        return [pod_info['pod'] for pod_info in pod_status if pod_info['phase'] == 'running']
+        log.debug("Running pods : " + str(running_pods))
+
+        return running_pods

--- a/hyperkops/monitor/pods_monitor.py
+++ b/hyperkops/monitor/pods_monitor.py
@@ -40,7 +40,9 @@ class PodMonitor:
         for trial in trials_list:
             if self.get_pod_name_from_owner_string(trial['owner'][0]) in list(deleted_pods):
                 trial['state'] = JOB_STATE_ERROR
-                log.warning("Trial deleted from MongoDB owner = " + str(trial['owner'][0]))
+                log.warning("Trial deleted from MongoDB owner = " +
+                            self.get_pod_name_from_owner_string(str(trial['owner'][0])))
+
                 # Upsert the job into mongodb
                 self.mongodb_connection.collection.replace_one({'_id': trial['_id']}, trial, True)
                 counter += 1


### PR DESCRIPTION
## What changes are proposed in this pull request?
* Reducing CPU request for the stale job monitor
* Fixing typo in the query to find running pods which was causing all trials to be deleted

## How was this patch tested?
Testing on docker-for-desktop

Infrastructure launched using
```kubectl apply -f kube-deploy-hyperkops-infrastructure.yaml```

```kubectl get pods``` renders our running pods:
￼
![image](https://user-images.githubusercontent.com/18350465/60409478-2589c200-9c07-11e9-948f-5bf25eca6281.png)

Port mapping allows access to MongoDB.  
Then launch test optimisation jobs:
```python optimisation.py -d localhost -p 27017 -t models -c jobs -e 100 -m 2```

Logs from the stale job monitor show it running correctly 
![image](https://user-images.githubusercontent.com/18350465/60409506-4e11bc00-9c07-11e9-89cd-9995407c6c7e.png)

Deleting the deployment removes the worker pod (creating a stale job in MongoDB)

```kubectl delete deployment hyperkops-workers```
```kubectl get pods```

![image](https://user-images.githubusercontent.com/18350465/60409533-697cc700-9c07-11e9-8d7d-2f2d1fb66604.png)

Logs from stale job monitor show stale trial was identified and removed 
￼
![image](https://user-images.githubusercontent.com/18350465/60409576-8d400d00-9c07-11e9-883c-1731ad061d86.png)


With the worker deployment restarted the job can finish
![image](https://user-images.githubusercontent.com/18350465/60409562-81544b00-9c07-11e9-9b7b-df2699db92cf.png)

![image](https://user-images.githubusercontent.com/18350465/60409566-84e7d200-9c07-11e9-9224-6a42ea6cd52d.png)

